### PR TITLE
fixed mismatch in deps

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,7 @@
 build --announce_rc
 build --verbose_failures
 build --config=clang
+build --action_env=DOCKER_API_VERSION
 build --compilation_mode=opt
 build --output_filter='^//((?!(third_party):).)*$'
 build --color=yes

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,15 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 ### register Python toolchain -- note this toolchain defines the path to a specific version of python
 load("//builders/bazel:deps.bzl", "python_deps", "python_register_toolchains")
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
+    sha256 = "f6dcb97e992f13bc9effd794e9bb300f06b0dadc88061f81ae68d8d5994be964",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_docker/releases/download/v0.26.0/rules_docker-v0.26.0.tar.gz",
+        "https://github.com/bazelbuild/rules_docker/releases/download/v0.26.0/rules_docker-v0.26.0.tar.gz",
+    ],
 )
 
 python_deps()
@@ -21,6 +24,12 @@ http_archive(
     urls = [
         "https://github.com/privacysandbox/data-plane-shared-libraries/archive/b442136d9cbe2872d8d55da95d176fd9a2d77b68.zip",
     ],
+    patches = [
+        "//third_party:data_plane_shared_libraries_libbpf.patch",
+        "//third_party:data_plane_shared_libraries_runsc_retry.patch",
+    ],
+    patch_args = ["-p1"],
+    patch_tool = "patch",
 )
 
 load(

--- a/builders/images/build-debian/install_apps
+++ b/builders/images/build-debian/install_apps
@@ -124,7 +124,11 @@ function install_docker() {
   echo "deb [arch=${arch} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${dist} ${lsb_release} stable" \
     | tee /etc/apt/sources.list.d/docker.list
   apt_update
-  apt-get --quiet install -y --no-install-recommends docker-ce docker-ce-cli containerd.io
+  # pin docker 24+ so client supports API 1.44 (required by docker engine 29+)
+  apt-get --quiet install -y --no-install-recommends \
+    docker-ce="5:24.*" \
+    docker-ce-cli="5:24.*" \
+    containerd.io
 }
 
 function install_clang_tidy() {

--- a/builders/tools/cbuild
+++ b/builders/tools/cbuild
@@ -234,6 +234,9 @@ else
 fi
 if [[ ${WITH_DOCKER_SOCK} -eq 1 ]]; then
   DOCKER_RUN_ARGS+=("--volume=/var/run/docker.sock:/var/run/docker.sock")
+  # docker engine 29+ requires API 1.44; older clients in the image report 1.42
+  # force docker client to use 1.44 when talking to host daemon
+  DOCKER_RUN_ARGS+=("--env=DOCKER_API_VERSION=1.44")
 fi
 for evar in "${ENV_VARS[@]}"
 do

--- a/services/bidding_service/byob/generate_bid_byob_dispatch_client.cc
+++ b/services/bidding_service/byob/generate_bid_byob_dispatch_client.cc
@@ -30,12 +30,11 @@ absl::StatusOr<GenerateBidByobDispatchClient>
 GenerateBidByobDispatchClient::Create(int num_workers) {
   PS_ASSIGN_OR_RETURN(
       auto byob_service,
-      roma_service::ByobGenerateProtectedAudienceBidService<>::Create(
+      (roma_service::ByobGenerateProtectedAudienceBidService<>::Create(
           {
-          //  .lib_mounts = "",
               .enable_seccomp_filter = true,
           },
-          /*mode=*/Mode::kModeNsJailSandbox);
+          /*mode=*/Mode::kModeNsJailSandbox)));
   return GenerateBidByobDispatchClient(std::move(byob_service), num_workers);
 }
 

--- a/third_party/data_plane_shared_libraries_libbpf.patch
+++ b/third_party/data_plane_shared_libraries_libbpf.patch
@@ -1,0 +1,10 @@
+--- a/src/roma/byob/container/Dockerfile.runsc
++++ b/src/roma/byob/container/Dockerfile.runsc
+@@ -12,6 +12,6 @@
+   crossbuild-essential-amd64="12.9*" \
+   crossbuild-essential-arm64="12.9*" \
+   gnupg="2.2.*" \
+-  libbpf-dev="1:1.1.0-*" \
++  libbpf-dev \
+   "$(test "${TARGETARCH}" = amd64 && echo libc6-dev-i386="2.36-*" || true)" \
+   lsb-release="12.0-*" \

--- a/third_party/data_plane_shared_libraries_runsc_retry.patch
+++ b/third_party/data_plane_shared_libraries_runsc_retry.patch
@@ -1,0 +1,17 @@
+--- a/src/roma/byob/container/Dockerfile.runsc
++++ b/src/roma/byob/container/Dockerfile.runsc
+@@ -76,13 +76,7 @@
+ WORKDIR /workspace/gvisor
+ RUN --mount=type=cache,target=/root/.cache/bazel \
+   --mount=type=cache,target=/bazel_root/gvisor_build \
+-  bazel build \
+-  --cache_test_results=no \
+-  --curses=no \
+-  --progress_report_interval=10 \
+-  --show_progress_rate_limit=10 \
+-  //runsc \
+-  && cp /workspace/gvisor/bazel-bin/runsc/runsc_/runsc /tmp
++  bash -c 'for i in 1 2 3 4 5; do bazel build --cache_test_results=no --curses=no --progress_report_interval=10 --show_progress_rate_limit=10 //runsc && cp /workspace/gvisor/bazel-bin/runsc/runsc_/runsc /tmp && exit 0; echo "Bazel fetch failed (attempt $i), retrying in 30s..."; sleep 30; done; exit 1'
+ 
+ #
+ # export the runsc binary


### PR DESCRIPTION
Fixes:

**rules_docker 403**
- WORKSPACE: Bump io_bazel_rules_docker v0.25.0 → v0.26.0 so go_puller URLs use a working mirror (v0.25.0 returned 403).

**Docker API 1.42 vs 1.44**
- builders/tools/cbuild: Set --env=DOCKER_API_VERSION=1.44 when mounting the Docker socket.
- builders/images/build-debian/install_apps: Pin docker-ce / docker-ce-cli to 5:24.*.
- .bazelrc: Add build --action_env=DOCKER_API_VERSION. Host Docker 29+ expects API 1.44; build container was 1.42.

**libbpf-dev on Bookworm**
- third_party/data_plane_shared_libraries_libbpf.patch: In external Dockerfile.runsc, change libbpf-dev="1:1.1.0-*" → libbpf-dev (no pin).
- WORKSPACE: Apply via google_privacysandbox_servers_common http_archive with patches, patch_args = ["-p1"], patch_tool = "patch". Pinned version not in Bookworm; default package fixes runsc image build.

**Transient 502 in runsc fetch**
- third_party/data_plane_shared_libraries_runsc_retry.patch: Wrap bazel build //runsc in a bash retry loop (5 attempts, 30s delay) in same Dockerfile.runsc.
- WORKSPACE: Add this patch to same http_archive. GitHub sometimes returns 502 for dependency fetches; retries make runsc build reliable.

**C++ macro in bidding_service**
- services/bidding_service/byob/generate_bid_byob_dispatch_client.cc: Wrap the full ByobGenerateProtectedAudienceBidService<>::Create(...) call in parentheses as the second argument to PS_ASSIGN_OR_RETURN; remove commented .lib_mounts line.
Commas inside the expression were parsed as extra macro arguments → “unterminated function-like macro” and brace errors; parentheses make it a single argument.